### PR TITLE
Add helm interface to list all the gulp tasks.

### DIFF
--- a/gulpjs-helm.el
+++ b/gulpjs-helm.el
@@ -1,0 +1,82 @@
+;;; gulpjs-helm.el --- Node's gulp helm support fur Emacs
+
+;; Copyright (C) 2014 Steven Rémot
+;; Copyright (C) 2015 zilongshanren
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; Author: Steven Rémot
+;; Version: 0.0.1
+
+;;; Commentary:
+
+;; This package offers a basic support of gulp, the javascript streaming
+;; build system, for Emacs.
+
+;; Installation:
+
+;; First, you should put the gulpjs directory in your load path:
+
+;; (add-to-list 'load-path "<path-to-gulpjs-dir>")
+
+;; Then, you can either require the whole file in your *init.el*:
+
+;; (require 'gulpjs-helm)
+
+;; Usage:
+
+;; When you are visiting a file in a project using gulp, simply use the
+;; command `M-x gulpjs-helm-start-task`, which will prompt you for the task to
+;; start.  gulp process will be started, its output redirected to the
+;; buffer named `*gulp*` by default.
+
+;; You can restart a stopped process by either pressing *g* in the gulp
+;; buffer, or using `M-x gulpjs-restart-task`.
+
+;;  State of the project:
+
+;; This package is a tiny code that I wrote to fit my specific and very
+;; basic use of gulp.  If you think some useful functionality could be
+;; added, feel free to open an issue so we can talk about it.
+
+;; License:
+
+;; This code is released under the GPL v3. See *COPYING* for more
+;; details.
+
+(require 'helm)
+(require 'gulpjs)
+
+(defun gulpjs-start-task-with-name (task)
+  "Start a gulp task in a specified buffer.
+
+TASK is a string specifying the task to start."
+  (let ((file-name (buffer-file-name))
+        (buffer (gulpjs-open-buffer)))
+    (with-current-buffer buffer
+      (gulpjs-create-process-for-task file-name task))
+    (switch-to-buffer-other-window buffer)))
+
+;;;###autoload
+(defun gulpjs-helm-start-tasks ()
+  "Select an gulps task and start it."
+  (interactive)
+  (helm :sources
+        '(((name . "Gulp Tasks")
+           (candidates . gulpjs-list-all-gulp-tasks)
+           (action . gulpjs-start-task-with-name)))))
+
+(provide 'gulpjs-helm)
+
+;;; gulpjs-helm.el ends here

--- a/gulpjs.el
+++ b/gulpjs.el
@@ -91,12 +91,7 @@
 Start to look in DIRECTORY.
 
 Return nil of no gulp file has been found."
-  (when (file-directory-p directory)
-    (if (member gulpjs-file-name (directory-files directory))
-        (file-name-as-directory directory)
-      (let ((parent (file-name-directory (directory-file-name directory))))
-        (when (not (string-equal directory parent))
-          (gulpjs-get-root parent))))))
+  (locate-dominating-file directory gulpjs-file-name))
 
 (defun gulpjs-open-buffer ()
   "Open a buffer for gulpjs output."

--- a/gulpjs.el
+++ b/gulpjs.el
@@ -58,6 +58,8 @@
 ;; This code is released under the GPL v3. See *COPYING* for more
 ;; details.
 
+(require 'ido)
+
 ;;; Code:
 (defgroup gulpjs
   '()
@@ -108,8 +110,8 @@ EVENT is the proces' status change."
 (defun gulpjs-create-process-for-task (file-name task)
   "Launch the gulp process in FILE-NAME for TASK."
   (setq default-directory (gulpjs-get-root (if (file-directory-p file-name)
-                                             file-name
-                                           (file-name-directory file-name)))
+                                               file-name
+                                             (file-name-directory file-name)))
         gulpjs-task task
         gulpjs-directory default-directory)
   (if default-directory
@@ -120,13 +122,21 @@ EVENT is the proces' status change."
     (error "Cannot find gulp file")
     (kill-buffer)))
 
+(defun gulpjs-list-all-gulp-tasks ()
+  "List all the gulp taks in simple format."
+  (split-string
+   (shell-command-to-string
+    "gulp --tasks-simple")
+   "\n"
+   t))
+
 ;;;###autoload
 (defun gulpjs-start-task ()
   "Start a gulp task in a specified buffer.
 
 TASK is a string specifying the task to start."
   (interactive)
-  (let ((task (read-string "Enter a gulp task : "))
+  (let ((task (ido-completing-read "Enter a gulp task : " (gulpjs-list-all-gulp-tasks)))
         (file-name (buffer-file-name))
         (buffer (gulpjs-open-buffer)))
     (with-current-buffer buffer


### PR DESCRIPTION
1. simplify the logic to lookup the gulpjs file
2. Add helm interface to list all the gulp tasks.
3. use ido complete for entering gulp tasks in gulpjs core.
